### PR TITLE
Add MM depends

### DIFF
--- a/Stockalike/SASS-DRP.netkan
+++ b/Stockalike/SASS-DRP.netkan
@@ -12,6 +12,7 @@
 		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/151632-DRP/"
 	},
 	"depends": [
+		{ "name": "ModuleManager" },
 		{ "name": "StockalikeSolarSystem" }
 	],
 	"install": [

--- a/Stockalike/SASS-ER.netkan
+++ b/Stockalike/SASS-ER.netkan
@@ -8,10 +8,12 @@
 	"author": "Sigma88",
 	"license": "restricted",
 	"download": "https://github.com/Sigma88/Sigma-EveRecolor/releases/download/v1.2.4/Sigma-EveRecolor.v1.2.4.zip",
+	"$vref": "#/ckan/ksp-avc",
 	"resources": {
 		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/122481-EveRecolor/"
 	},
 	"depends": [
+		{ "name": "ModuleManager" },
 		{ "name": "StockalikeSolarSystem" }
 	],
 	"install": [

--- a/Stockalike/SASS-NH.netkan
+++ b/Stockalike/SASS-NH.netkan
@@ -12,6 +12,7 @@
 		"homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/102776-NH/"
 	},
 	"depends": [
+		{ "name": "ModuleManager" },
 		{ "name": "StockalikeSolarSystem" }
 	],
 	"install": [

--- a/Stockalike/SASS-OPM.netkan
+++ b/Stockalike/SASS-OPM.netkan
@@ -8,10 +8,12 @@
 	"author": "Galileo88",
 	"license": "CC-BY-NC-SA-4.0",
 	"download": "https://github.com/Galileo88/OPM_Galileo/releases/download/1.2.4/OPM_Galileo.v1.2.4.zip",
+	"$vref": "#/ckan/ksp-avc",
 	"resources": {
 		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/165854-OPMG/"
 	},
 	"depends": [
+		{ "name": "ModuleManager" },
 		{ "name": "StockalikeSolarSystem" }
 	],
 	"install": [

--- a/Stockalike/SASS-RevJ.netkan
+++ b/Stockalike/SASS-RevJ.netkan
@@ -12,6 +12,7 @@
 		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/142085-RevJ/"
 	},
 	"depends": [
+		{ "name": "ModuleManager" },
 		{ "name": "StockalikeSolarSystem" }
 	],
 	"install": [

--- a/Stockalike/SASS-RevSS.netkan
+++ b/Stockalike/SASS-RevSS.netkan
@@ -12,6 +12,7 @@
 		"homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/134360-rsss/"
 	},
 	"depends": [
+		{ "name": "ModuleManager" },
 		{ "name": "StockalikeSolarSystem" }
 	],
 	"install": [

--- a/Stockalike/SASS-SE.netkan
+++ b/Stockalike/SASS-SE.netkan
@@ -12,6 +12,7 @@
 		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/117355-SE/"
 	},
 	"depends": [
+		{ "name": "ModuleManager" },
 		{ "name": "StockalikeSolarSystem" }
 	],
 	"install": [

--- a/Stockalike/SASS-Saru.netkan
+++ b/Stockalike/SASS-Saru.netkan
@@ -12,6 +12,7 @@
 		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/119263-Saru/"
 	},
 	"depends": [
+		{ "name": "ModuleManager" },
 		{ "name": "StockalikeSolarSystem" }
 	],
 	"install": [

--- a/Stockalike/SASS-UL.netkan
+++ b/Stockalike/SASS-UL.netkan
@@ -12,6 +12,7 @@
 		"homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/120111-ul/"
 	},
 	"depends": [
+		{ "name": "ModuleManager" },
 		{ "name": "StockalikeSolarSystem" }
 	],
 	"install": [


### PR DESCRIPTION
Several mods here use ModuleManager syntax but don't depend on it in their metanetkans.
Now they do.

And two of them have version files that weren't being used.
Now they'll be used.

Tagginng @Sigma88 since not everyone has notifications turned on for GitHub pull requests.